### PR TITLE
Change end date

### DIFF
--- a/ios/RNCalendarEvents.m
+++ b/ios/RNCalendarEvents.m
@@ -124,8 +124,14 @@ RCT_EXPORT_MODULE()
         NSDate *exceptionDate = [RCTConvert NSDate:options[@"exceptionDate"]];
 
         if(exceptionDate) {
+            NSCalendar *cal = [NSCalendar currentCalendar];
+            NSDate *endPredicateDate = [cal dateByAddingUnit:NSCalendarUnitDay
+                                     value:1
+                                    toDate:exceptionDate
+                                   options:0];
+
             NSPredicate *predicate = [self.eventStore predicateForEventsWithStartDate:exceptionDate
-                                                                              endDate:endDate
+                                                                              endDate:endPredicateDate
                                                                             calendars:nil];
             NSArray *calendarEvents = [self.eventStore eventsMatchingPredicate:predicate];
 


### PR DESCRIPTION
Changing recurring events so that the end date is earlier than the previous start date will cause an error. I fixed it.